### PR TITLE
fix: eip712 domain fields encoded in spec order

### DIFF
--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -13,6 +13,9 @@ from hexbytes import HexBytes
 from eip712.hashing import hash_domain
 from eip712.hashing import hash_message as hash_eip712_message
 
+# ! Do not change the order of the fields in this list !
+# To correctly encode and hash the domain fields, they
+# must be in this precise order.
 EIP712_DOMAIN_FIELDS = [
     "name",
     "version",
@@ -20,7 +23,7 @@ EIP712_DOMAIN_FIELDS = [
     "verifyingContract",
     "salt",
 ]
-HEADER_FIELDS = set(f"_{field}_" for field in EIP712_DOMAIN_FIELDS)
+HEADER_FIELDS = [f"_{field}_" for field in EIP712_DOMAIN_FIELDS]
 
 
 # https://github.com/ethereum/eth-account/blob/f1d38e0/eth_account/messages.py#L39
@@ -138,10 +141,12 @@ class EIP712Message(EIP712Type):
     @property
     def domain(self) -> dict:
         """The EIP-712 domain fields (built using ``HEADER_FIELDS``)."""
+        # Ensure that HEADER_FIELDS are in the following order:
+        # name, version, chainId, verifyingContract, salt
         return {
             field.replace("_", ""): getattr(self, field)
-            for field in fields(self.__class__, internals=True)
-            if field in HEADER_FIELDS
+            for field in HEADER_FIELDS
+            if field in fields(self.__class__, internals=True)
         }
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,22 @@ class ValidMessageWithNameDomainField(EIP712Message):
     sub: SubType
 
 
+class MessageWithNonCanonicalDomainFieldOrder(EIP712Message):
+    _name_: "string" = PERMIT_NAME  # type: ignore
+    _salt_: "bytes32" = PERMIT_SALT  # type: ignore
+    _chainId_: "uint256" = PERMIT_CHAIN_ID  # type: ignore
+    _version_: "string" = PERMIT_VERSION  # type: ignore
+    _verifyingContract_: "address" = PERMIT_VAULT_ADDRESS  # type: ignore
+
+
+class MessageWithCanonicalDomainFieldOrder(EIP712Message):
+    _name_: "string" = PERMIT_NAME  # type: ignore
+    _version_: "string" = PERMIT_VERSION  # type: ignore
+    _chainId_: "uint256" = PERMIT_CHAIN_ID  # type: ignore
+    _verifyingContract_: "address" = PERMIT_VAULT_ADDRESS  # type: ignore
+    _salt_: "bytes32" = PERMIT_SALT  # type: ignore
+
+
 class MessageWithInvalidNameType(EIP712Message):
     _name_: str = "Invalid Test Message"  # type: ignore
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -4,9 +4,9 @@ from eip712.messages import ValidationError
 
 from .conftest import (
     InvalidMessageMissingDomainFields,
+    MessageWithCanonicalDomainFieldOrder,
     MessageWithInvalidNameType,
     MessageWithNonCanonicalDomainFieldOrder,
-    MessageWithCanonicalDomainFieldOrder,
 )
 
 

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -2,7 +2,12 @@ import pytest
 
 from eip712.messages import ValidationError
 
-from .conftest import InvalidMessageMissingDomainFields, MessageWithInvalidNameType
+from .conftest import (
+    InvalidMessageMissingDomainFields,
+    MessageWithInvalidNameType,
+    MessageWithNonCanonicalDomainFieldOrder,
+    MessageWithCanonicalDomainFieldOrder,
+)
 
 
 def test_multilevel_message(valid_message_with_name_domain_field):
@@ -34,3 +39,10 @@ def test_yearn_vaults_message(permit, permit_raw_data):
     """
 
     assert permit.body_data == permit_raw_data
+
+
+def test_eip712_domain_field_order_is_invariant():
+    assert (
+        MessageWithCanonicalDomainFieldOrder.domain
+        == MessageWithNonCanonicalDomainFieldOrder.domain
+    )


### PR DESCRIPTION
See issue #23 for reference. It also includes a link to a stack overflow question with extensive discussion on why this change here is made.

I am happy to work on more tests around EIP712 signatures, however, tests need to be fixed first. I noticed 2 tests are failing and 2 are succeeding (before this change on `main` branch); so those need to be addressed independently of this PR, first.