### PR TITLE
chore: fix pinning of `eth-typing`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "dataclassy>=0.8.2,<1",
         "eth-utils>=2.1.0,<3",
         "eth-abi>=3.0.1,<4",
-        "eth-typing>=3.2,<4",
+        "eth-typing>=2.3.0,<4",
         "hexbytes>=0.3.0,<1",
         "pycryptodome>=3.16.0,<4",
     ],


### PR DESCRIPTION
### What I did

Apparently, `web3` v5 is pinned to an earlier version of `eth-typing`, so just relax the pin a bit

fixes: #30

### How I did it

### How to verify it

- [x] Ensure we're not using anything specific to `eth-typing` v3 or higher

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
