### PR TITLE
feat: upgrade eth dependencies [APE-728]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 # setuptools-scm
 version.py
+
+# Ape projects
+.build/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,10 @@ def get_versions() -> List[str]:
     versions = [
         d.name
         for d in build_dir.iterdir()
-        if d.is_dir and pattern.match(d.stem) and "beta" not in d.name and "alpha" not in d.name
+        if d.is_dir  # type: ignore
+        and pattern.match(d.stem)
+        and "beta" not in d.name
+        and "alpha" not in d.name
     ]
 
     return versions

--- a/eip712/common.py
+++ b/eip712/common.py
@@ -53,7 +53,7 @@ class SafeTxV1(EIP712Message):
     # NOTE: Subclass this as `SafeTx` w/ at least one header field
     to: "address"  # type: ignore
     value: "uint256" = 0  # type: ignore
-    data: "bytes" = b""  # type: ignore
+    data: "bytes" = b""
     operation: "uint8" = 0  # type: ignore
     safeTxGas: "uint256" = 0  # type: ignore
     dataGas: "uint256" = 0  # type: ignore
@@ -67,7 +67,7 @@ class SafeTxV2(EIP712Message):
     # NOTE: Subclass this as `SafeTx` w/ at least one header field
     to: "address"  # type: ignore
     value: "uint256" = 0  # type: ignore
-    data: "bytes" = b""  # type: ignore
+    data: "bytes" = b""
     operation: "uint8" = 0  # type: ignore
     safeTxGas: "uint256" = 0  # type: ignore
     baseGas: "uint256" = 0  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ extras_require = {
         "pytest>=6.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
-        "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
+        "hypothesis>=6.70.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.12.0",  # auto-formatter and linter
-        "mypy>=0.991",  # Static type analyzer
+        "black>=23.1.0,<24",  # auto-formatter and linter
+        "mypy>=1.1.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
-        "flake8>=6.0.0",  # Style linter
-        "isort>=5.10.1",  # Import sorting linter
+        "flake8>=6.0.0,<7",  # Style linter
+        "isort>=5.12.0",  # Import sorting linter
         "mdformat>=0.7.16",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
@@ -25,15 +25,14 @@ extras_require = {
         "twine",  # Package upload tool
     ],
     "doc": [
-        "myst-parser>=0.17.0,<0.18",  # Tools for parsing markdown files in the docs
-        "sphinx-click>=3.1.0,<4.0",  # For documenting CLI
-        "Sphinx>=4.4.0,<5.0",  # Documentation generator
+        "myst-parser>=0.18.1,<0.19",  # Tools for parsing markdown files in the docs
+        "Sphinx>=5.3.0,<6.0",  # Documentation generator
         "sphinx_rtd_theme>=1.0.0,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "dev": [
-        "commitizen>=2.19,<2.20",  # Manage commits and publishing releases
-        "pre-commit",  # Ensure that linters are run prior to commiting
+        "commitizen>=2.42,<3.0",  # Manage commits and publishing releases
+        "pre-commit",  # Ensure that linters are run prior to committing
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting
         "ipdb",  # Debugger (Must use `export PYTHONBREAKPOINT=ipdb.set_trace`)

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,14 @@ extras_require = {
         "twine",  # Package upload tool
     ],
     "doc": [
-        "myst-parser>=0.18.1,<0.19",  # Tools for parsing markdown files in the docs
-        "Sphinx>=5.3.0,<6.0",  # Documentation generator
-        "sphinx_rtd_theme>=1.2.0,<2",  # Readthedocs.org theme
+        "myst-parser>=0.17.0,<0.18",  # Tools for parsing markdown files in the docs
+        "sphinx-click>=3.1.0,<4.0",  # For documenting CLI
+        "Sphinx>=4.4.0,<5.0",  # Documentation generator
+        "sphinx_rtd_theme>=1.0.0,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "dev": [
-        "commitizen>=2.42,<3.0",  # Manage commits and publishing releases
+        "commitizen>=2.19,<2.20",  # Manage commits and publishing releases
         "pre-commit",  # Ensure that linters are run prior to commiting
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting
@@ -65,12 +66,12 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-abi>=2.2.0,<4",
-        "eth-account>0.4.0,<1.0.0",
-        "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
-        "eth-typing>=2.3,<4",
-        "eth-utils>=1.9.5,<3",
+        "eth-utils>=2.1.0,<3",
+        "eth-abi==4.0.0b2",
+        "eth-typing>=3.3.0,<4",
+        "eth-account>=0.8.0,<0.9",
         "hexbytes>=0.3.0,<1",
+        "pycryptodome>=3.16.0,<4",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
-        "pytest>=6.0",  # Core testing package
+        "pytest>=6.0,<8",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
-        "hypothesis>=6.70.0,<7.0",  # Strategy-based fuzzer
+        "hypothesis>=6.70.0,<7",  # Strategy-based fuzzer
     ],
     "lint": [
         "black>=23.1.0,<24",  # auto-formatter and linter
@@ -16,8 +16,8 @@ extras_require = {
         "flake8>=6.0.0,<7",  # Style linter
         "isort>=5.12.0,<6",  # Import sorting linter
         "mdformat>=0.7.16,<0.8",  # Auto-formatter for markdown
-        "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
-        "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-gfm>=0.3.5,<0.4",  # Needed for formatting GitHub-flavored markdown
+        "mdformat-frontmatter>=0.4.1,<0.5",  # Needed for frontmatters-style headers in issue templates
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ extras_require = {
         "mypy>=1.1.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "flake8>=6.0.0,<7",  # Style linter
-        "isort>=5.12.0",  # Import sorting linter
-        "mdformat>=0.7.16",  # Auto-formatter for markdown
+        "isort>=5.12.0,<6",  # Import sorting linter
+        "mdformat>=0.7.16,<0.8",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         "isort>=5.12.0,<6",  # Import sorting linter
         "mdformat>=0.7.16,<0.8",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5,<0.4",  # Needed for formatting GitHub-flavored markdown
-        "mdformat-frontmatter>=0.4.1,<0.5",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-frontmatter>=0.4.1,<0.5",  # Needed for headers in GH issue templates
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ extras_require = {
     ],
     "doc": [
         "myst-parser>=0.18.1,<0.19",  # Tools for parsing markdown files in the docs
-        "Sphinx>=5.3.0,<6.0",  # Documentation generator
+        "Sphinx>=5.3.0,<6",  # Documentation generator
         "sphinx_rtd_theme>=1.2.0,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "dev": [
-        "commitizen>=2.42,<3.0",  # Manage commits and publishing releases
+        "commitizen>=2.42,<3",  # Manage commits and publishing releases
         "pre-commit",  # Ensure that linters are run prior to committing
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ extras_require = {
     "doc": [
         "myst-parser>=0.18.1,<0.19",  # Tools for parsing markdown files in the docs
         "Sphinx>=5.3.0,<6.0",  # Documentation generator
-        "sphinx_rtd_theme>=1.0.0,<2",  # Readthedocs.org theme
+        "sphinx_rtd_theme>=1.2.0,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "dev": [
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-abi==4.0.0b2",
+        "eth-abi==4.0.0b3",
         "eth-account>=0.8.0,<0.9",
         "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
         "eth-typing>=3.3.0,<4",

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-abi==4.0.0b3",
+        "eth-abi>=4.0.0,<5",
         "eth-account>=0.8.0,<0.9",
         "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
         "eth-typing>=3.3.0,<4",

--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,12 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-utils>=2.1.0,<3",
         "eth-abi==4.0.0b2",
-        "eth-typing>=3.3.0,<4",
         "eth-account>=0.8.0,<0.9",
+        "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
+        "eth-typing>=3.3.0,<4",
+        "eth-utils>=2.1.0,<3",
         "hexbytes>=0.3.0,<1",
-        "pycryptodome>=3.16.0,<4",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

Upgrades `eth-abi` and `eth-account` to be in a range compatible with `web3.py==6.0.0`

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
