### PR TITLE
chore: widen pin for eth-abi [APE-802]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-abi>=4.0.0,<5",
+        "eth-abi>=3.0,<5",
         "eth-account>=0.8.0,<0.9",
         "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
         "eth-typing>=3.3.0,<4",


### PR DESCRIPTION
### What I did

titanoboa was having issues upgrading to eth-abi 4.x series, but needs this package. I investigating and saw that we only need a function that hasn't changed since introduction in 2.x series, so I widened the pin for them.

### How I did it

git blame

### How to verify it

It works for boa use cases