### PR TITLE
feat: add `calculate_hash` method for getting EIP712 hash [APE-1578]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.11.0
     hooks:
       - id: black
         name: black
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.7.1
     hooks:
     -   id: mypy
         additional_dependencies: [types-setuptools, pydantic]

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -153,6 +153,6 @@ class EIP712Message(EIP712Type):
     def eip712_hash(self) -> HexBytes:
         """
         The hash of the fully encoded EIP-712 ``value`` for ``types`` with ``domain``.
-        Inspired from
+        Inspired from Safe Wallet's transaction hash calculation.
         """
         return HexBytes(keccak(b"".join([bytes.fromhex("19"), *self.signable_message])))

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -141,11 +141,11 @@ class EIP712Message(EIP712Type):
     def signable_message(self) -> SignableMessage:
         """The current message as a :class:`SignableMessage` named tuple instance."""
         return SignableMessage(
-            HexBytes(bytes.fromhex("1901")),
+            HexBytes(1),
             HexBytes(hash_domain(self._domain_)),
             HexBytes(hash_eip712_message(self._body_)),
         )
 
     @property
     def message_hash(self) -> HexBytes:
-        return HexBytes(keccak(b"".join(self.signable_message)))
+        return HexBytes(keccak(b"".join([bytes.fromhex("19"), *self.signable_message])))

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -149,10 +149,6 @@ class EIP712Message(EIP712Type):
             HexBytes(hash_eip712_message(self._body_)),
         )
 
-    @property
-    def eip712_hash(self) -> HexBytes:
-        """
-        The hash of the fully encoded EIP-712 ``value`` for ``types`` with ``domain``.
-        Inspired from Safe Wallet's transaction hash calculation.
-        """
-        return HexBytes(keccak(b"".join([bytes.fromhex("19"), *self.signable_message])))
+
+def calculate_hash(msg: SignableMessage) -> HexBytes:
+    return HexBytes(keccak(b"".join([bytes.fromhex("19"), *msg])))

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -1,12 +1,12 @@
 """
 Message classes for typed structured data hashing and signing in Ethereum.
 """
-
 from typing import Any, Dict, Optional
 
 from dataclassy import dataclass, fields
 from eth_abi import is_encodable_type
 from eth_account.messages import SignableMessage, hash_domain, hash_eip712_message
+from eth_utils import keccak
 from eth_utils.curried import ValidationError
 from hexbytes import HexBytes
 
@@ -119,6 +119,7 @@ class EIP712Message(EIP712Type):
     @property
     def _body_(self) -> dict:
         """The EIP-712 structured message to be used for serialization and hashing."""
+
         return {
             "domain": self._domain_["domain"],
             "types": dict(self._types_, **self._domain_["types"]),
@@ -140,7 +141,11 @@ class EIP712Message(EIP712Type):
     def signable_message(self) -> SignableMessage:
         """The current message as a :class:`SignableMessage` named tuple instance."""
         return SignableMessage(
-            HexBytes(b"\x01"),
+            HexBytes(bytes.fromhex("1901")),
             HexBytes(hash_domain(self._domain_)),
             HexBytes(hash_eip712_message(self._body_)),
         )
+
+    @property
+    def message_hash(self) -> HexBytes:
+        return HexBytes(keccak(b"".join(self.signable_message)))

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -139,7 +139,10 @@ class EIP712Message(EIP712Type):
 
     @property
     def signable_message(self) -> SignableMessage:
-        """The current message as a :class:`SignableMessage` named tuple instance."""
+        """
+        The current message as a :class:`SignableMessage` named tuple instance.
+        **NOTE**: The 0x19 prefix is NOT included.
+        """
         return SignableMessage(
             HexBytes(1),
             HexBytes(hash_domain(self._domain_)),

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -150,5 +150,9 @@ class EIP712Message(EIP712Type):
         )
 
     @property
-    def message_hash(self) -> HexBytes:
+    def eip712_hash(self) -> HexBytes:
+        """
+        The hash of the fully encoded EIP-712 ``value`` for ``types`` with ``domain``.
+        Inspired from
+        """
         return HexBytes(keccak(b"".join([bytes.fromhex("19"), *self.signable_message])))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,4 @@
 import pytest
-from ape import convert
 from eth_account._utils.structured_data.hashing import hash_message
 from hexbytes import HexBytes
 
@@ -44,7 +43,7 @@ def test_gnosis_goerli_safe_tx():
     msg = tx_def(
         to=receiver,
         nonce=0,
-        value=convert("1 ETH", int),
+        value=1_000_000_000_000_000_000,
     )
     actual = msg.message_hash
     expected = HexBytes("0xbbb1cbed7c3679b5d5764df26af8fab1b15f3a15c084db9082dffb3624ca74ee")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,6 +3,7 @@ from eth_account._utils.structured_data.hashing import hash_message
 from hexbytes import HexBytes
 
 from eip712.common import SAFE_VERSIONS, create_safe_tx_def
+from eip712.messages import calculate_hash
 
 MAINNET_MSIG_ADDRESS = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
 GOERLI_MSIG_ADDRESS = "0x3c59eC3912A6A0c8690ec548D87FB55C3Ba62aBa"
@@ -45,6 +46,6 @@ def test_gnosis_goerli_safe_tx():
         nonce=0,
         value=1_000_000_000_000_000_000,
     )
-    actual = msg.eip712_hash
+    actual = calculate_hash(msg.signable_message)
     expected = HexBytes("0xbbb1cbed7c3679b5d5764df26af8fab1b15f3a15c084db9082dffb3624ca74ee")
     assert actual == expected

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -45,6 +45,6 @@ def test_gnosis_goerli_safe_tx():
         nonce=0,
         value=1_000_000_000_000_000_000,
     )
-    actual = msg.message_hash
+    actual = msg.eip712_hash
     expected = HexBytes("0xbbb1cbed7c3679b5d5764df26af8fab1b15f3a15c084db9082dffb3624ca74ee")
     assert actual == expected

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,20 +1,23 @@
 import pytest
-from eth_account.messages import hash_eip712_message as hash_message
+from ape import convert
+from eth_account._utils.structured_data.hashing import hash_message
+from hexbytes import HexBytes
 
 from eip712.common import SAFE_VERSIONS, create_safe_tx_def
 
-MSIG_ADDRESS = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+MAINNET_MSIG_ADDRESS = "0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52"
+GOERLI_MSIG_ADDRESS = "0x3c59eC3912A6A0c8690ec548D87FB55C3Ba62aBa"
 
 
 @pytest.mark.parametrize("version", SAFE_VERSIONS)
 def test_gnosis_safe_tx(version):
     tx_def = create_safe_tx_def(
         version=version,
-        contract_address=MSIG_ADDRESS,
+        contract_address=MAINNET_MSIG_ADDRESS,
         chain_id=1,
     )
 
-    msg = tx_def(to=MSIG_ADDRESS, nonce=0)
+    msg = tx_def(to=MAINNET_MSIG_ADDRESS, nonce=0)
 
     assert msg.signable_message.header.hex() == (
         "0x88fbc465dedd7fe71b7baef26a1f46cdaadd50b95c77cbe88569195a9fe589ab"
@@ -27,3 +30,22 @@ def test_gnosis_safe_tx(version):
         if version in ("1.3.0",)
         else "1b393826bed1f2297ffc01916f8339892f9a51dc7f35f477b9a5cdd651d28603"
     )
+
+
+def test_gnosis_goerli_safe_tx():
+    tx_def = create_safe_tx_def(
+        version="1.3.0",
+        contract_address=GOERLI_MSIG_ADDRESS,
+        chain_id=5,
+    )
+
+    # Fields matching actual nonce=0 tx from wallet.
+    receiver = "0x3c59eC3912A6A0c8690ec548D87FB55C3Ba62aBa"
+    msg = tx_def(
+        to=receiver,
+        nonce=0,
+        value=convert("1 ETH", int),
+    )
+    actual = msg.message_hash
+    expected = HexBytes("0xbbb1cbed7c3679b5d5764df26af8fab1b15f3a15c084db9082dffb3624ca74ee")
+    assert actual == expected


### PR DESCRIPTION
### What I did

Adds a method to easily get the hash of an Eip712 object, needed for safe tx work

### How I did it

copy from safe python sdk

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
