### PR TITLE
chore: loosen `eth-abi` pin to allow `5.x.x` releases

### DIFF
--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -4,7 +4,7 @@ Message classes for typed structured data hashing and signing in Ethereum.
 from typing import Any, Dict, Optional
 
 from dataclassy import asdict, dataclass, fields
-from eth_abi.abi import is_encodable_type
+from eth_abi.abi import is_encodable_type  # type: ignore[import-untyped]
 from eth_account.messages import SignableMessage, hash_domain, hash_eip712_message
 from eth_utils import keccak
 from eth_utils.curried import ValidationError

--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -4,7 +4,7 @@ Message classes for typed structured data hashing and signing in Ethereum.
 from typing import Any, Dict, Optional
 
 from dataclassy import asdict, dataclass, fields
-from eth_abi import is_encodable_type
+from eth_abi.abi import is_encodable_type
 from eth_account.messages import SignableMessage, hash_domain, hash_eip712_message
 from eth_utils import keccak
 from eth_utils.curried import ValidationError

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dataclassy>=0.8.2,<1",
-        "eth-abi>=4.2.1,<5",
+        "eth-abi>=4.2.1,<6",
         "eth-account>=0.10.0,<0.11",
         "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
         "eth-typing>=3.5.2,<4",


### PR DESCRIPTION
### What I did
Loosen the `eth-abi` pin to allow `5.x.x` releases.

The only [breaking change](https://github.com/ethereum/eth-abi/blob/main/docs/release_notes.rst#eth-abi-v500-2024-01-09) introduced in `eth-abi==5.0.0` is dropping support for Python 3.7, which is already not supported by this package.  I opted not to bump the minimum required version so as to avoid potential disruption of any downstream dependencies.

### How I did it
Modified the pin in `setup.py`.

### How to verify it
Read the diff.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
