### PR TITLE
chore: update eth-account and hexbytes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,11 +66,11 @@ setup(
     install_requires=[
         "dataclassy>=0.8.2,<1",
         "eth-abi>=5.1.0,<6",
-        "eth-account>=0.10.0,<0.12",
+        "eth-account>=0.12.0,<0.14",
         "eth-hash[pycryptodome]",  # NOTE: Pinned by eth-abi
         "eth-typing>=3.5.2,<4",
         "eth-utils>=2.3.1,<3",
-        "hexbytes>=0.3.0,<1",
+        "hexbytes>=1.2.0,<2",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,5 @@
 import pytest
-from eth_account._utils.structured_data.hashing import hash_message
+from eth_account.messages import encode_typed_data, _hash_eip191_message
 from hexbytes import HexBytes
 
 from eip712.common import SAFE_VERSIONS, create_safe_tx_def
@@ -20,12 +20,12 @@ def test_gnosis_safe_tx(version):
     msg = tx_def(to=MAINNET_MSIG_ADDRESS, nonce=0)
 
     assert msg.signable_message.header.hex() == (
-        "0x88fbc465dedd7fe71b7baef26a1f46cdaadd50b95c77cbe88569195a9fe589ab"
+        "88fbc465dedd7fe71b7baef26a1f46cdaadd50b95c77cbe88569195a9fe589ab"
         if version in ("1.3.0",)
-        else "0x590e9c66b22ee4584cd655fda57748ce186b85f829a092c28209478efbe86a92"
+        else "590e9c66b22ee4584cd655fda57748ce186b85f829a092c28209478efbe86a92"
     )
 
-    assert hash_message(msg).hex() == (
+    assert msg.signable_message.body.hex() == (
         "3c2fdf2ea8af328a67825162e7686000787c5cc9f4b27cb6bfbcaa445b59e2c4"
         if version in ("1.3.0",)
         else "1b393826bed1f2297ffc01916f8339892f9a51dc7f35f477b9a5cdd651d28603"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,4 @@
 import pytest
-from eth_account.messages import encode_typed_data, _hash_eip191_message
 from hexbytes import HexBytes
 
 from eip712.common import SAFE_VERSIONS, create_safe_tx_def

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -10,9 +10,9 @@ from .conftest import (
 
 def test_multilevel_message(valid_message_with_name_domain_field):
     msg = valid_message_with_name_domain_field.signable_message
-    assert msg.version.hex() == "0x01"
-    assert msg.header.hex() == "0x336a9d2b32d1ab7ea7bbbd2565eca1910e54b74843858dec7a81f772a3c17e17"
-    assert msg.body.hex() == "0x306af87567fa87e55d2bd925d9a3ed2b1ec2c3e71b142785c053dc60b6ca177b"
+    assert msg.version.hex() == "01"
+    assert msg.header.hex() == "336a9d2b32d1ab7ea7bbbd2565eca1910e54b74843858dec7a81f772a3c17e17"
+    assert msg.body.hex() == "306af87567fa87e55d2bd925d9a3ed2b1ec2c3e71b142785c053dc60b6ca177b"
 
 
 def test_invalid_message_without_domain_fields():


### PR DESCRIPTION
This PR updates eth-account. Note that this version has a few [breaking changes](https://eth-account.readthedocs.io/en/latest/release_notes.html) that are not used in this project.

### What I did
- Updated eth-account
- Updated hexbytes (dependency of eth-account)

### How I did it
Updating the requirements in setup.py

### How to verify it
Tests should still pass

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] ~~New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows