### PR TITLE
chore: adds windows OS classifier to setup.py

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,7 @@ jobs:
 
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
+                os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
         steps:

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
         "Natural Language :: English",
         "Operating System :: MacOS",
         "Operating System :: POSIX",
+        "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
### What I did

adds windows OS classifier to setup.py

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
