### PR TITLE
feat: make hashes available

### DIFF
--- a/eip712/messages.py
+++ b/eip712/messages.py
@@ -139,18 +139,32 @@ class EIP712Message(EIP712Type):
         return super().__getitem__(key)
 
     @property
+    def _domain_separator_(self) -> HexBytes:
+        """
+        The hashed domain.
+        """
+        domain = _prepare_data_for_hashing(self._domain_["domain"])
+        return HexBytes(hash_domain(domain))
+
+    @property
+    def _hash_struct_(self) -> HexBytes:
+        """
+        The hashed message.
+        """
+        types = _prepare_data_for_hashing(self._types_)
+        message = _prepare_data_for_hashing(self._body_["message"])
+        return HexBytes(hash_eip712_message(types, message))
+
+    @property
     def signable_message(self) -> SignableMessage:
         """
         The current message as a :class:`SignableMessage` named tuple instance.
         **NOTE**: The 0x19 prefix is NOT included.
         """
-        domain = _prepare_data_for_hashing(self._domain_["domain"])
-        types = _prepare_data_for_hashing(self._types_)
-        message = _prepare_data_for_hashing(self._body_["message"])
         return SignableMessage(
             HexBytes(1),
-            HexBytes(hash_domain(domain)),
-            HexBytes(hash_eip712_message(types, message)),
+            self._domain_separator_,
+            self._hash_struct_,
         )
 
 


### PR DESCRIPTION
### What I did

It is nice to have access to the domain separator and hashed struct.
I would also like to have access to the type hash directly, but that is abstracted away in `eth-account` too much

### How I did it

### How to verify it

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
